### PR TITLE
Jump to time 140565883

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,4 +18,5 @@ group :development, :test do
   gem 'byebug'
   gem 'timecop'
   gem 'simplecov'
+  gem 'pry'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,6 +46,7 @@ GEM
     arel (6.0.3)
     builder (3.2.2)
     byebug (9.0.6)
+    coderay (1.1.1)
     concurrent-ruby (1.0.2)
     docile (1.1.5)
     erubis (2.7.0)
@@ -53,11 +54,11 @@ GEM
       activesupport (>= 4.1.0)
     i18n (0.7.0)
     json (1.8.3)
-    kgio (2.10.0)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
     mail (2.6.4)
       mime-types (>= 1.16, < 4)
+    method_source (0.8.2)
     mime-types (3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
@@ -65,6 +66,10 @@ GEM
     minitest (5.10.1)
     nokogiri (1.7.0.1)
       mini_portile2 (~> 2.1.0)
+    pry (0.10.4)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
     rack (1.6.5)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -92,13 +97,13 @@ GEM
       activesupport (= 4.2.7.1)
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
-    raindrops (0.17.0)
     rake (12.0.0)
     simplecov (0.12.0)
       docile (~> 1.1.0)
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.0)
+    slop (3.6.0)
     sprockets (3.7.0)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -112,9 +117,6 @@ GEM
     timecop (0.8.1)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
-    unicorn (5.2.0)
-      kgio (~> 2.6)
-      raindrops (~> 0.7)
 
 PLATFORMS
   ruby
@@ -122,10 +124,10 @@ PLATFORMS
 DEPENDENCIES
   byebug
   delorean!
+  pry
   simplecov
   sqlite3
   timecop
-  unicorn
 
 BUNDLED WITH
    1.13.6

--- a/app/controllers/delorean/flux_capacitor_controller.rb
+++ b/app/controllers/delorean/flux_capacitor_controller.rb
@@ -6,12 +6,14 @@ module Delorean
     end
 
     def start
-      Time.now
+      session[:delorean_start_time] = Time.now
+      Timecop.return
       redirect_to root_path
     end
 
     def pause
-      Timecop.freeze
+      session[:delorean_pause_time] = Time.now
+      Timecop.freeze(session[:delorean_pause_time])
       redirect_to root_path
     end
 
@@ -21,7 +23,11 @@ module Delorean
     end
 
     def accelerate_to_eighty_eight
-      Timecop.freeze(params[:future])
+      puts params[:date]
+      session[:delorean_future] = DateTime.new(
+        *params[:date].values.map(&:to_i)
+      )
+      Timecop.travel(session[:delorean_future])
       redirect_to root_path
     end
   end

--- a/app/views/delorean/flux_capacitor/index.html.erb
+++ b/app/views/delorean/flux_capacitor/index.html.erb
@@ -1,4 +1,9 @@
 <%= button_to 'Time Circuits On (Start)', action: :start %>
 <%= button_to 'Time Circuits Off (Stop)', action: :pause %>
 <%= button_to 'Fluxing', action: :flux %>
-<%= button_to 'Accelerate to', action: :accelerate_to_eighty_eight %>
+<fieldset>
+  <%= form_tag accelerate_to_eighty_eight_flux_capacitor_index_path do %>
+    <%= select_datetime %>
+    <%= submit_tag 'Accelerate' %>
+  <% end %>
+</fieldset>


### PR DESCRIPTION
This allows us to travel to a time w/ timecop

- Standardize our session storage
 (Session storage instead of request storage so that we persist through requests)
- Date input field
- Travel instead of freeze the future

Dev tools
- Added pry