### PR TITLE
Change variable store to cache for backend processes 141048513

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    delorean (0.0.1)
+    delorean_test_bed (0.0.2)
       rails (~> 4.2.7.1)
       timecop
 
@@ -123,7 +123,7 @@ PLATFORMS
 
 DEPENDENCIES
   byebug
-  delorean!
+  delorean_test_bed!
   pry
   simplecov
   sqlite3

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Add this line to your application's Gemfile:
 
 ```ruby
 group :test, :development do
-  gem 'delorean'
+  gem 'delorean_test_bed'
 end
 ```
 
@@ -19,8 +19,8 @@ And then execute:
 
 Or install it yourself as:
 
-    $ gem install delorean
-    
+    $ gem install delorean_test_bed
+
 Add routes to your routes.rb
 
 ```ruby
@@ -39,6 +39,18 @@ flux (scale), or accelerate (jump) to the times you need to test.
 3. To Scale Time, enter a value > 1 and flux
 4. To Jump to A Time, accelerate (to 88mph) Time will change and continue to run.
 
+
+### Usage in Test Beds
+
+You may want to know the time factors (start, scale) when writing test beds.
+We've built a cache store so that any application (backend/frontend) can share
+this information.
+
+```ruby
+  Delorean::Cache.read(:start)
+  Delorean::Cache.read(:scale)
+  Delorean::Cache.read(:future)
+```
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/app/controllers/delorean/flux_capacitor_controller.rb
+++ b/app/controllers/delorean/flux_capacitor_controller.rb
@@ -3,32 +3,32 @@ require_dependency "delorean/application_controller"
 module Delorean
   class FluxCapacitorController < ApplicationController
     def index
-      @scale = session[:delorean_scale].to_i
+      @scale = Delorean::cache.read(:future).to_i
     end
 
     def start
-      session[:delorean_start_time] = Time.now
+      Delorean::cache.write(:start, Time.now)
       Timecop.return
       redirect_to root_path
     end
 
     def pause
-      session[:delorean_pause_time] = Time.now
-      Timecop.freeze(session[:delorean_pause_time])
+      Delorean::cache.write(:pause, Time.now)
+      Timecop.freeze(Delorean::cache.read(:pause))
       redirect_to root_path
     end
 
     def flux
-      session[:delorean_scale] = params[:scale]
+      Delorean::cache.write(:scale, params[:scale])
       Timecop.scale(params[:scale].to_i)
       redirect_to root_path
     end
 
     def accelerate_to_eighty_eight
-      session[:delorean_future] = DateTime.new(
+      Delorean::cache.write(:future, DateTime.new(
         *params[:date].values.map(&:to_i)
-      )
-      Timecop.travel(session[:delorean_future])
+      ))
+      Timecop.travel(Delorean::cache.read(:future))
       redirect_to root_path
     end
   end

--- a/app/views/delorean/flux_capacitor/index.html.erb
+++ b/app/views/delorean/flux_capacitor/index.html.erb
@@ -2,7 +2,7 @@
 <%= button_to 'Time Circuits Off (Stop)', action: :pause %>
 <fieldset>
   <%= form_tag flux_flux_capacitor_index_path do %>
-    <%= number_field_tag :scale, @scale, { type: :integer, scale: 1} %>
+    <%= number_field_tag :scale, @scale || 0, { type: :integer, scale: 1} %>
     <%= submit_tag 'Fluxing' %>
   <% end %>
 </fieldset>

--- a/delorean.gemspec
+++ b/delorean.gemspec
@@ -5,7 +5,7 @@ require "delorean/version"
 
 # Describe your gem and declare its dependencies:
 Gem::Specification.new do |s|
-  s.name        = "delorean"
+  s.name        = "delorean_test_bed"
   s.version     = Delorean::VERSION
   s.authors     = ["Stephen Reid","David Harkness","Terminus"]
   s.email       = ["stephen.reid@terminus.com"]

--- a/lib/delorean.rb
+++ b/lib/delorean.rb
@@ -1,4 +1,5 @@
 require "delorean/engine"
+require "delorean/cache"
 
 module Delorean
 end

--- a/lib/delorean/cache.rb
+++ b/lib/delorean/cache.rb
@@ -1,0 +1,20 @@
+module Delorean
+  def self.cache
+    Cache
+  end
+
+  class Cache
+    # Set our own cache or read the setup one
+    def self.cache
+      ActiveSupport::Cache.lookup_store(Rails.application.config.cache_store)
+    end
+    #
+    def self.write(k,v)
+      cache.write([:delorean,:key],v)
+    end
+
+    def self.read(k)
+      cache.read([:delorean,:key])
+    end
+  end
+end

--- a/lib/delorean/version.rb
+++ b/lib/delorean/version.rb
@@ -1,3 +1,3 @@
 module Delorean
-  VERSION = "0.0.1"
+  VERSION = "0.0.2"
 end

--- a/test/controllers/delorean/flux_capacitor_controller_test.rb
+++ b/test/controllers/delorean/flux_capacitor_controller_test.rb
@@ -18,7 +18,7 @@ module Delorean
     test 'POST #start' do
       post :start
       assert_response :redirect
-      assert_in_delta Time.now, session[:delorean_start_time], 1.seconds
+      assert_in_delta Time.now, Delorean.cache.read(:start), 1.seconds
     end
 
     test 'POST #flux' do
@@ -26,7 +26,7 @@ module Delorean
       post :flux, { scale: 1000 }
       sleep(0.25)
       assert_response :redirect
-      assert_equal 1000, session[:delorean_scale].to_i
+      assert_equal 1000, Delorean.cache.read(:scale).to_i
       refute_in_delta Time.now, current_time, 5.seconds
     end
 


### PR DESCRIPTION
Session information is not available for other processes such as jobs. As such, we need a cache store.

Namespaced this so that we won't run into objects otherwise cached.